### PR TITLE
Remove creation of test objects form spec_helper file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,18 +21,6 @@ RSpec.configure do |config|
 
   DatabaseCleaner.strategy = :truncation
 
-  config.before(:each) do
-    @crookshanks = User.create(name: "Crookshanks")
-    @kitten = User.create(name: "Kitten")
-    @post1 = Post.create(user_id: @crookshanks.id, name: "post title", content: "post content")
-    @post2 = Post.create(user_id: @crookshanks.id, name: "my second post", content: "post content")
-    @tag1 = Tag.create(name: "cute")
-    @tag2 = Tag.create(name: "adorable")
-    PostTag.create(:tag_id => @tag1.id, :post_id => @post1.id)
-    PostTag.create(:tag_id => @tag1.id, :post_id => @post2.id)
-    PostTag.create(:tag_id => @tag2.id, :post_id => @post1.id)
-  end
-
   config.after(:each) do
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
Objects for test were being double created, once in the spec_helper
and once in the spec file itself. This was causing tests to fail
because of a uniqueness validation required earlier in the lab.

Closes #13 

@pletcher @PeterBell 